### PR TITLE
Fuzzysearch para mejorar la busqueda de municipio

### DIFF
--- a/aemet/__init__.py
+++ b/aemet/__init__.py
@@ -1,14 +1,20 @@
 from aemet.models import *  # noqa
 import click
 
+
 @click.command()
-@click.option('-p', '--prediccion', help='Muestra la predicción meteorológica dado un nombre de municipio')
-def main(prediccion):
-    client = Aemet()
+@click.option(
+    "-p",
+    "--prediccion",
+    help="Muestra la predicción meteorológica dado un nombre de municipio",
+)
+@click.option("-k", "--key", help="API key AEMET")
+@click.option("-f", "--keyfile", help="Fichero con la clave de la AEMET.")
+def main(prediccion, key, keyfile):
+    client = Aemet(api_key=key, api_key_file=keyfile)
     municipio = Municipio.buscar(prediccion)
     p = client.get_prediccion(municipio.get_codigo())
     for dia in p.prediccion:
         print(dia.fecha)
-        print('Máxima: {}'.format(dia.temperatura['maxima']))
-        print('Mínima: {}'.format(dia.temperatura['minima']))
-        print()
+        print("Máxima: {}".format(dia.temperatura["maxima"]))
+        print("Mínima: {}\n".format(dia.temperatura["minima"]))

--- a/aemet/__init__.py
+++ b/aemet/__init__.py
@@ -14,6 +14,7 @@ def main(prediccion, key, keyfile):
     client = Aemet(api_key=key, api_key_file=keyfile)
     municipio = Municipio.buscar(prediccion)
     p = client.get_prediccion(municipio.get_codigo())
+    print(f"Predicción de temperaturas para {municipio.nombre}:\n")
     for dia in p.prediccion:
         print(dia.fecha)
         print("Máxima: {}".format(dia.temperatura["maxima"]))

--- a/aemet/models.py
+++ b/aemet/models.py
@@ -284,7 +284,7 @@ class Municipio:
         :param nombre: Nombre del municipio
         """
         try:
-            match_ratios = list(map(lambda m: fuzz.ratio(nombre.lower(), m.get("NOMBRE").lower()), Municipio.MUNICIPIOS))
+            match_ratios = list(map(lambda m: fuzz.token_set_ratio(nombre, m.get("NOMBRE")), Municipio.MUNICIPIOS))
             best_match = max(match_ratios)
             idx_best_match = match_ratios.index(best_match)
             municipio = Municipio.from_json(Municipio.MUNICIPIOS[idx_best_match])

--- a/aemet/models.py
+++ b/aemet/models.py
@@ -2,6 +2,7 @@ import requests
 import json
 import urllib3
 from datetime import datetime
+from fuzzywuzzy import fuzz
 from aemet.constants import *
 
 # Disable Insecure Request Warnings
@@ -279,15 +280,17 @@ class Municipio:
     @staticmethod
     def buscar(nombre):
         """
-        Devuelve una lista con los resultados de la búsqueda
+        Devuelve el resultado de la búsqueda entre todos los municipios de España.
         :param nombre: Nombre del municipio
         """
         try:
-            municipios_raw = list(filter(lambda t: nombre in t.get('NOMBRE'), Municipio.MUNICIPIOS))
-            municipios = list(map(lambda m: Municipio.from_json(m), municipios_raw))
-            return municipios
-        except:
-            return None
+            match_ratios = list(map(lambda m: fuzz.ratio(nombre.lower(), m.get("NOMBRE").lower()), Municipio.MUNICIPIOS))
+            best_match = max(match_ratios)
+            idx_best_match = match_ratios.index(best_match)
+            municipio = Municipio.from_json(Municipio.MUNICIPIOS[idx_best_match])
+            return municipio
+        except e:
+            print(f"Ha habido un error {e}")
 
     def get_codigo(self):
         return '{}{}'.format(self.cpro, self.cmun)

--- a/aemet/models.py
+++ b/aemet/models.py
@@ -3,6 +3,7 @@ import json
 import urllib3
 from datetime import datetime
 from fuzzywuzzy import fuzz
+# ToDo: eliminar este import de todos los elementos del modulo
 from aemet.constants import *
 
 # Disable Insecure Request Warnings

--- a/aemet/models.py
+++ b/aemet/models.py
@@ -1,8 +1,8 @@
-import requests
 import json
+import requests
 import urllib3
 from datetime import datetime
-from fuzzywuzzy import fuzz
+from fuzzywuzzy import process
 # ToDo: eliminar este import de todos los elementos del modulo
 from aemet.constants import *
 
@@ -285,9 +285,9 @@ class Municipio:
         :param nombre: Nombre del municipio
         """
         try:
-            match_ratios = list(map(lambda m: fuzz.token_set_ratio(nombre, m.get("NOMBRE")), Municipio.MUNICIPIOS))
-            best_match = max(match_ratios)
-            idx_best_match = match_ratios.index(best_match)
+            nombres_municipios = list(map(lambda m: m.get("NOMBRE"), Municipio.MUNICIPIOS))
+            best_match = process.extractOne(nombre, nombres_municipios)
+            idx_best_match = nombres_municipios.index(best_match[0])
             municipio = Municipio.from_json(Municipio.MUNICIPIOS[idx_best_match])
             return municipio
         except e:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,30 +4,16 @@
 
 ### Instalar la librería `python-aemet`
 
-- Tener `python3` instalado en el sistema: `which python`
+-   Tener `python3` instalado en el sistema: `which python`
 
-- Instalar la librería en el local. Recomendamos el uso de un `virtualenv`.
+-   Instalar la librería en el local. Recomendamos el uso de un `virtualenv` o un gestor
+    de entornos como `pyenv`.
 
-   E.g. Instala `virtualenv`:
+      Instala la librería
 
-   ```bash
-   pip install virtualenv
-   ```
-
-  Clona el repo `git clone git@github.com:pablo-moreno/python-aemet.git && cd python-aemet`
-
-  Activa el `virtualenv`:
-
-  ```bash
-  virtualenv .venv
-  source .venv/bin/activate
-  ```
-
-  Instala la librería
-
-  ```bash
-  pip install .
-  ```
+    ```bash
+    pip install python-aemet
+    ```
 
 ### Obtener la clave API
 
@@ -42,39 +28,39 @@ Y ponla en un fichero `aemet.key`
 ### Predicción de la temperatura máxima y mínima en un municipio concreto en los próximos días
 
 ```bash
-aemet -p Madrid -f /path/a/la/clave/aemet.key
+aemet -p Huelva -f /path/a/la/clave/aemet.key
 ```
 
 La salida:
 
 ```sh
-Predicción de temperaturas para Madrid:
-
-2021-04-03T00:00:00
-Máxima: 20
-Mínima: 10
+Predicción de temperaturas para Huelva:
 
 2021-04-04T00:00:00
-Máxima: 20
-Mínima: 7
+Máxima: 23
+Mínima: 12
 
 2021-04-05T00:00:00
 Máxima: 22
-Mínima: 7
+Mínima: 13
 
 2021-04-06T00:00:00
-Máxima: 22
-Mínima: 7
+Máxima: 25
+Mínima: 11
 
 2021-04-07T00:00:00
-Máxima: 19
-Mínima: 4
+Máxima: 25
+Mínima: 13
 
 2021-04-08T00:00:00
-Máxima: 18
-Mínima: 9
+Máxima: 23
+Mínima: 12
 
 2021-04-09T00:00:00
-Máxima: 20
-Mínima: 10
+Máxima: 21
+Mínima: 12
+
+2021-04-10T00:00:00
+Máxima: 21
+Mínima: 13
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# Casos de uso de `python-aemet`
+
+## Requisitos previos
+
+### Instalar la librería `python-aemet`
+
+- Tener `python3` instalado en el sistema: `which python`
+
+- Instalar la librería en el local. Recomendamos el uso de un `virtualenv`.
+
+   E.g. Instala `virtualenv`:
+
+   ```bash
+   pip install virtualenv
+   ```
+
+  Clona el repo `git clone git@github.com:pablo-moreno/python-aemet.git && cd python-aemet`
+
+  Activa el `virtualenv`:
+
+  ```bash
+  virtualenv .venv
+  source .venv/bin/activate
+  ```
+
+  Instala la librería
+
+  ```bash
+  pip install .
+  ```
+
+### Obtener la clave API
+
+Obtén tu clave de API en la siguiente URL:
+
+<https://opendata.aemet.es/centrodedescargas/obtencionAPIKey>
+
+Y ponla en un fichero `aemet.key`
+
+## Casos de uso
+
+### Predicción de la temperatura máxima y mínima en un municipio concreto en los próximos días
+
+```bash
+aemet -p Madrid -f /path/a/la/clave/aemet.key
+```
+
+La salida:
+
+```sh
+Predicción de temperaturas para Madrid:
+
+2021-04-03T00:00:00
+Máxima: 20
+Mínima: 10
+
+2021-04-04T00:00:00
+Máxima: 20
+Mínima: 7
+
+2021-04-05T00:00:00
+Máxima: 22
+Mínima: 7
+
+2021-04-06T00:00:00
+Máxima: 22
+Mínima: 7
+
+2021-04-07T00:00:00
+Máxima: 19
+Mínima: 4
+
+2021-04-08T00:00:00
+Máxima: 18
+Mínima: 9
+
+2021-04-09T00:00:00
+Máxima: 20
+Mínima: 10
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 urllib3
 requests
 click
+fuzzywuzzy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ urllib3
 requests
 click
 fuzzywuzzy
+python-Levenshtein


### PR DESCRIPTION
## Resumen

- [x] Cierra #29 
- [x] Añade fuzzy search a la búsqueda por municipio devolviendo el municipio más cercano a la secuencia de entrada.
 
### Descripción de la contribución

La motivación fue que al usar la interfaz CLI me di cuenta de que el método `buscar` de la clase `Municipio` devolvia una lista con los municipios cuya busqueda simple por nombre arrojara los resultados que contuvieran la cadena de entrada.

Pienso que quiza devolver el municipio mas cercano de una busqueda hecha con `fuzzywuzzy` y la distancia Levenshtein que es lo que quiza el usuario anda buscando.

Por ejemplo, una cadena incompleta como:

```
 aemet -p "Rivas" -f /home/jose/Dropbox/keys/aemet.key
```
Arrojaria:

```
Predicción de temperaturas para Rivas-Vaciamadrid:

2021-04-03T00:00:00
Máxima: 21
Mínima: 6
...
```

Y otra con faltas de ortografia como:
```
aemet -p "Velez Malaga" -f /home/jose/Dropbox/keys/aemet.key
```
Resultaria:

```
Predicción de temperaturas para Vélez-Málaga:

2021-04-03T00:00:00
Máxima: 25
Mínima: 13
...
```
