### PR TITLE
Mejora de solicitud de información de contaminación de fondo

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,6 @@
 - José Luis Garrido [@kalanda](https://github.com/kalanda)
 - Carlos Alarcón [@jchuerva](https://github.com/jchuerva)
 - Daniel Argüeso [@dargueso](https://github.com/dargueso)
-- r3v1 [@r3v1](https://github.com/r3v1)
+- David Revillas [@r3v1](https://github.com/r3v1)
 - pherodeon [@pherodeon](https://github.com/pherodeon)
 - Jose Rivera-Rubio [jmrr](https://github.com/jmrr)

--- a/aemet/models.py
+++ b/aemet/models.py
@@ -688,7 +688,7 @@ class Aemet(AemetHttpClient):
         # TODO
         return data
 
-    def get_contaminacion_fondo(self, estacion, raw=False):
+    def get_contaminacion_fondo(self, estacion, raw=True):
         """
         Obtiene los datos de contaminación de fondo. (último elaborado)
 


### PR DESCRIPTION
Propongo una mejora del método para obtener información de la contaminación de fondo.

La respuesta a la solicitud de AEMET es un `str`. Si a este método se le pasa el parámetro `raw=True`, éste devolverá una `list` (como previamente estaba). En cambio, con `raw=False`, devolverá un `dict` de la siguiente forma:

```
{
    "2021-11-08 11:00": {
         "SO2(001): 1.26,
        ...
    }
}
```